### PR TITLE
Remote session picker

### DIFF
--- a/tmuxc
+++ b/tmuxc
@@ -890,14 +890,24 @@ sub RemoteSessions {
   my @rsessions = qx(@cmd);
   Log( LOG_DEBUG, \@rsessions );
 
+  my $instances = InstanceCheck();
+
+  my @ksessions;
+  if ( defined( $instances->{running} ) ) {
+    @ksessions = @{ $instances->{running} };
+    Log( LOG_DEBUG, \@ksessions );
+  }
+
   my $pid = open2( $child_out, $child_in, @{ $config->{selector} } );
 
   for my $hostsession ( sort @rsessions ) {
     chomp($hostsession);
     my ( $rsession, undef ) = split( /:/, $hostsession );
     next if ( $rsession =~ m/^tmuxc\// );
+    $rsession = "$rsession\@$host";
+    next if ( grep { $_ eq $rsession } @ksessions );
     Log( LOG_DEBUG, "Prompting for $rsession" );
-    print $child_in "$rsession\@$host\n";
+    print $child_in "$rsession\n";
   }
 
   close($child_in);

--- a/tmuxc
+++ b/tmuxc
@@ -118,6 +118,12 @@ GetOptions(
       KnownSessions( $cli{csv} );
     };
   },
+  "remote|K:s" => sub {
+    ( undef, my $rhost ) = @_;
+    $cliAction = sub {
+      RemoteSessions($rhost);
+    }
+  },
   "menu|m" => sub {
     $cliAction = sub {
       Menu("paged");
@@ -859,6 +865,47 @@ sub EphemeralSession {
   }
 
   LaunchNewInstance( join( '@', $session, $host ), "-E" );
+  exit;
+}
+
+sub RemoteSessions {
+  my $host = shift;
+
+  my ( $child_out, $child_in, @prompt );
+
+  # Prompt for a host if none were provided
+  unless ( length($host) ) {
+    @prompt = @{ $config->{input_prompt} };
+    push( @prompt, "Host" );
+    my $pid = open2( $child_out, $child_in, @prompt );
+
+    print $child_in "";
+    close($child_in);
+    $host = <$child_out>;
+    exit unless defined($host);
+    chomp($host);
+  }
+
+  my @cmd       = buildCommand( $host, [ $config->{tmux_bin}, qw(list-sessions) ] );
+  my @rsessions = qx(@cmd);
+  Log( LOG_DEBUG, \@rsessions );
+
+  my $pid = open2( $child_out, $child_in, @{ $config->{selector} } );
+
+  for my $hostsession ( sort @rsessions ) {
+    chomp($hostsession);
+    my ( $rsession, undef ) = split( /:/, $hostsession );
+    next if ( $rsession =~ m/^tmuxc\// );
+    Log( LOG_DEBUG, "Prompting for $rsession" );
+    print $child_in "$rsession\@$host\n";
+  }
+
+  close($child_in);
+  my $response = <$child_out>;
+  exit unless defined($response);
+  chomp($response);
+
+  LaunchNewInstance( $response, "--poe none" );
   exit;
 }
 

--- a/tmuxc
+++ b/tmuxc
@@ -1648,6 +1648,10 @@ Enable single-window-mode. This opens up a single terminal for an entire tmux se
 
 List active and inactive sessions. Takes an optional character argument to enable CSV output for machine parsing.
 
+=item B<remote|K> | B<remote|K host>
+
+List tmux sessions on a remote host that do not have a local instance of tmuxc attached to them, then connect to the session.
+
 =item B<--print|o>
 
 Print configuration options for the host and session selected from command line arguments.
@@ -1686,9 +1690,9 @@ Issue the raw tmux command I<new-window -d> to the default session on localhost.
 
 =head1 SCRIPTING
 
-Each running instance of tmuxc creates a command FIFO that can be used to control tmux and tmuxc. The FIFO takes the form of F<hostname-session.control>, and by default is available in F<~/.tmuxc/control/>. Once you've written a command to the FIFO, send the B<USR1> signal to tmuxc. The PID is available in F<~/.tmuxc/pid/hostname-session.pid>. 
+Each running instance of tmuxc creates a command FIFO that can be used to control tmux and tmuxc. The FIFO takes the form of F<hostname-session.control>, and by default is available in F<~/.tmuxc/control/>. Once you've written a command to the FIFO, send the B<USR1> signal to tmuxc. The PID is available in F<~/.tmuxc/pid/hostname-session.pid>.
 
-See B<RAW COMMANDS> for examples. 
+See B<RAW COMMANDS> for examples.
 
 =head1 RAW COMMANDS
 
@@ -1719,8 +1723,7 @@ Instruct tmuxc to cleanly exit.
 
 =item B<PauseSelf>
 
-Instruct tmuxc to ignore all input from the command line and from tmux, until this 
-option is toggled again.
+Instruct tmuxc to ignore all input from the command line and from tmux, until this option is toggled again.
 
 =item B<LoadConfig>
 


### PR DESCRIPTION
I routinely create a number of one-off remote sessions on a bastion host. However, when I switch to my laptop, these sessions are not in a config file or otherwise accessible. This mode enables a user to find all sessions on a given host that are currently not actively attached by the local machine and then attach to one. Single-window versus multi-window mode is inherited from `.tmuxc.conf`.